### PR TITLE
MOB-8257 expose notifyNotification for SFMC

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationJsDelivery.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationJsDelivery.java
@@ -39,7 +39,7 @@ public class RNPushNotificationJsDelivery {
         sendEvent("remoteFetch", params);
     }
 
-    void notifyNotification(Bundle bundle) {
+    public void notifyNotification(Bundle bundle) {
         String bundleString = convertJSON(bundle);
 
         WritableMap params = Arguments.createMap();


### PR DESCRIPTION
Expose this logic so SFMC push notification data can be sent to JS on Android.